### PR TITLE
Rename onDestroy callback to onDispose

### DIFF
--- a/app/src/main/java/com/monday8am/lottierecorder/MainActivity.kt
+++ b/app/src/main/java/com/monday8am/lottierecorder/MainActivity.kt
@@ -81,7 +81,7 @@ fun Content(
                 Text("Success: ${state.uri}")
                 Media3Player(
                     uri = state.uri,
-                    onDestroy = { },
+                    onDispose = { },
                     modifier = Modifier.fillMaxWidth(),
                 )
             }

--- a/app/src/main/java/com/monday8am/lottierecorder/ui/Media3Player.kt
+++ b/app/src/main/java/com/monday8am/lottierecorder/ui/Media3Player.kt
@@ -22,10 +22,15 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 
+/**
+ * Displays the video at [uri] using Media3.
+ *
+ * @param onDispose Callback reporting playback progress when the player view is disposed.
+ */
 @Composable
 internal fun Media3Player(
     uri: String,
-    onDestroy: (Float) -> Unit,
+    onDispose: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var currentPosition by rememberSaveable { mutableLongStateOf(0L) }
@@ -35,7 +40,7 @@ internal fun Media3Player(
             currentPosition = position
 
             val progress = (position.toFloat() / duration.toFloat()).coerceIn(0f, 1f)
-            onDestroy(progress)
+            onDispose(progress)
         }
 
     Box(


### PR DESCRIPTION
## Summary
- rename onDestroy parameter to onDispose in Media3Player
- document that onDispose reports progress when the player view is disposed
- update Media3Player call site

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b681a5c7a08322bdf50ed496e1e7dc